### PR TITLE
Add a method to update the size and position of the spinner.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # spin
 
   Higher level spinner API auto positioning and scaling
@@ -23,6 +22,11 @@
 ```js
 var s = spin(document.querySelector('.one'));
 ```
+
+### Spinner#update()
+
+  Augments the `Spinner` returned with an `.update()` method,
+  which updates the size and position of the spinner.
 
 ### Spinner#remove()
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -31,20 +30,26 @@ module.exports = function(el, options){
   options = options || {};
   var ms = options.delay || 300;
 
-  var w = el.offsetWidth;
-  var h = el.offsetHeight;
+  // update size and position
+  spin.update = function(){
+    debug('update');
+    var w = el.offsetWidth;
+    var h = el.offsetHeight;
 
-  // size
-  var s = options.size || w / 5;
-  spin.size(s);
-  debug('show %dpx (%dms)', s, ms);
+    // size
+    var s = options.size || w / 5;
+    spin.size(s);
+    debug('show %dpx (%dms)', s, ms);
 
-  // position
-  css(spin.el, {
-    position: 'absolute',
-    top: h / 2 - s / 2,
-    left: w / 2 - s / 2
-  });
+    // position
+    css(spin.el, {
+      position: 'absolute',
+      top: h / 2 - s / 2,
+      left: w / 2 - s / 2
+    });
+  }
+
+  spin.update();
 
   // remove
   spin.remove = function(){


### PR DESCRIPTION
If the container change its size, you can't update the size and position of the spinner. You should remove the spinner from DOM and create it again to update its values:

``` js
spin.remove();
spin(el);
```

Now, you can use a simple method, avoiding DOM manipulation:

``` js
spin.update();
```

Thanks.
