### PR TITLE
Avoid dom error when trying to remove an already removed Node

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,15 +3,23 @@
   "repo": "component/spin",
   "description": "Higher level spinner API",
   "version": "0.0.2",
-  "keywords": ["spin", "spinner", "load", "loading", "progress"],
+  "keywords": [
+    "spin",
+    "spinner",
+    "load",
+    "loading",
+    "progress"
+  ],
   "dependencies": {
     "component/css": "*",
     "visionmedia/debug": "*",
-    "component/spinner": "0.1.0"
+    "component/spinner": "0.1.0",
+    "component/removed": "*"
   },
   "development": {},
   "license": "MIT",
   "scripts": [
     "index.js"
-  ]
+  ],
+  "remotes": []
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@
 
 var Spinner = require('spinner')
   , debug = require('debug')('spin')
-  , css = require('css');
+  , css = require('css')
+  , removed = require('removed');
 
 /**
  * Add a spinner to `el`,
@@ -65,6 +66,10 @@ module.exports = function(el, options){
     appended = true;
     el.appendChild(spin.el);
   }, ms);
+
+  removed(spin.el, function() {
+    appended = false;
+  });
 
   return spin;
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "debug": "*",
     "css-component": "*",
-    "spinner-component2": "0.1.0"
+    "spinner-component2": "0.1.0",
+    "removed-component": "0.0.3"
   },
   "development": {},
   "license": "MIT",


### PR DESCRIPTION
In case the `spin.el` is removed from DOM because of a parent element change, when calling `spin.remove()` throws the following:

``` js
Uncaught NotFoundError: An attempt was made to reference a Node in a context where it does not exist
```

I added a `removed` listener with `component/removed` to change the `appended` flag to `false`.
